### PR TITLE
Adds jest argument '--ci' for running test.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY . ./
 RUN yarn
 RUN yarn build:development
-RUN yarn test --watchAll=false
+RUN yarn test --ci --watchAll=false
 
 # Stage 2 - the production environment
 FROM nginx:alpine

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY . ./
 RUN yarn
 RUN yarn build:production
-RUN yarn test --watchAll=false
+RUN yarn test --ci --watchAll=false
 
 # Stage 2 - the production environment
 FROM nginx:alpine


### PR DESCRIPTION
When '--ci' option is provided, Jest will assume it is running in a CI environment. This changes the behavior when a new snapshot is encountered. Instead of the regular behavior of storing a new snapshot automatically, it will fail the test and require Jest to be run with --updateSnapshot.